### PR TITLE
#221: Fix missing list markers in chat markdown (#224)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -263,9 +263,30 @@ label:has(> select#reasoning-effort) select {
   margin: 0.65rem 0;
 }
 
-.chat-markdown ul,
+.chat-markdown ul {
+  padding-left: 1.25rem;
+  list-style-type: disc;
+}
+
 .chat-markdown ol {
   padding-left: 1.25rem;
+  list-style-type: decimal;
+}
+
+.chat-markdown ul ul {
+  list-style-type: circle;
+}
+
+.chat-markdown ul ul ul {
+  list-style-type: square;
+}
+
+.chat-markdown ol ol {
+  list-style-type: lower-alpha;
+}
+
+.chat-markdown ol ol ol {
+  list-style-type: lower-roman;
 }
 
 .chat-markdown li + li {


### PR DESCRIPTION
Tailwind v4 Preflight resets list-style to none on ul/ol elements. Restore disc/decimal markers and add nested list style variants (circle, square, lower-alpha, lower-roman) for visual distinction.