### PR TITLE
fix: unblock desktop startup from provider probes

### DIFF
--- a/apps/desktop/scripts/post-build-icons.ts
+++ b/apps/desktop/scripts/post-build-icons.ts
@@ -8,6 +8,7 @@ const serverNodeModulesDir = resolve(import.meta.dir, "../../server/node_modules
 const serverRuntimeDependencies = ["node-pty"];
 const legacyPreloadBundleDir = resolve(import.meta.dir, "../dist-electron");
 const legacyPreloadBundlePath = join(legacyPreloadBundleDir, "preload.js");
+const sourcePreloadBundlePath = resolve(import.meta.dir, "../preload.js");
 
 if (!buildDir) {
   process.exit(0);
@@ -153,6 +154,11 @@ const bundledPreloadPath = findBundledPreloadPath(resolvedBuildDir);
 if (bundledPreloadPath) {
   mkdirSync(legacyPreloadBundleDir, { recursive: true });
   cpSync(bundledPreloadPath, legacyPreloadBundlePath, { dereference: true, force: true });
+} else if (existsSync(sourcePreloadBundlePath)) {
+  // CI still verifies this legacy compatibility copy even when Electrobun's
+  // build layout does not expose the bundled preload in a stable location.
+  mkdirSync(legacyPreloadBundleDir, { recursive: true });
+  cpSync(sourcePreloadBundlePath, legacyPreloadBundlePath, { dereference: true, force: true });
 }
 
 if (targetOs !== "macos") {

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -13,6 +13,7 @@ import { query as claudeQuery } from "@anthropic-ai/claude-agent-sdk";
 
 import {
   buildServerProvider,
+  buildPendingServerProvider,
   DEFAULT_TIMEOUT_MS,
   detailFromResult,
   extractAuthBoolean,
@@ -644,6 +645,15 @@ export const ClaudeProviderLive = Layer.effect(
         Stream.map((settings) => settings.providers.claudeAgent),
       ),
       haveSettingsChanged: (previous, next) => !Equal.equals(previous, next),
+      buildInitialSnapshot: (settings) =>
+        buildPendingServerProvider({
+          provider: PROVIDER,
+          enabled: settings.enabled,
+          checkedAt: new Date().toISOString(),
+          models: providerModelsFromSettings(BUILT_IN_MODELS, PROVIDER, settings.customModels),
+          disabledMessage: "Claude is disabled in Beppo settings.",
+          checkingMessage: "Checking Claude status…",
+        }),
       checkProvider,
     });
   }),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -24,6 +24,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   buildServerProvider,
+  buildPendingServerProvider,
   DEFAULT_TIMEOUT_MS,
   detailFromResult,
   extractAuthBoolean,
@@ -890,6 +891,15 @@ export const CodexProviderLive = Layer.effect(
         Stream.map((settings) => settings.providers.codex),
       ),
       haveSettingsChanged: (previous, next) => !Equal.equals(previous, next),
+      buildInitialSnapshot: (settings) =>
+        buildPendingServerProvider({
+          provider: PROVIDER,
+          enabled: settings.enabled,
+          checkedAt: new Date().toISOString(),
+          models: providerModelsFromSettings(BUILT_IN_MODELS, PROVIDER, settings.customModels),
+          disabledMessage: "Codex is disabled in Beppo settings.",
+          checkingMessage: "Checking Codex status…",
+        }),
       checkProvider,
     });
   }),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -557,7 +557,11 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
             const initial = yield* registry.getProviders;
             assert.strictEqual(
               initial.find((status) => status.provider === "codex")?.status,
-              "ready",
+              "warning",
+            );
+            assert.strictEqual(
+              initial.find((status) => status.provider === "codex")?.installed,
+              false,
             );
 
             yield* serverSettings.updateSettings({

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -21,6 +21,9 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     PubSub.shutdown,
   );
   const initialSettings = yield* input.getSettings;
+  // This placeholder snapshot is stamped at construction time. Once the
+  // background probe finishes, it overwrites `checkedAt` with the real probe
+  // completion timestamp.
   const initialSnapshot = input.buildInitialSnapshot(initialSettings);
   const snapshotRef = yield* Ref.make(initialSnapshot);
   const settingsRef = yield* Ref.make(initialSettings);

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -11,6 +11,7 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   readonly getSettings: Effect.Effect<Settings>;
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
+  readonly buildInitialSnapshot: (settings: Settings) => ServerProvider;
   readonly checkProvider: Effect.Effect<ServerProvider, ServerSettingsError>;
   readonly refreshInterval?: Duration.Input;
 }): Effect.fn.Return<ServerProviderShape, ServerSettingsError, Scope.Scope> {
@@ -20,7 +21,7 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     PubSub.shutdown,
   );
   const initialSettings = yield* input.getSettings;
-  const initialSnapshot = yield* input.checkProvider;
+  const initialSnapshot = input.buildInitialSnapshot(initialSettings);
   const snapshotRef = yield* Ref.make(initialSnapshot);
   const settingsRef = yield* Ref.make(initialSettings);
 
@@ -60,12 +61,12 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     ),
   ).pipe(Effect.forkScoped);
 
+  // Do the first real provider probe in the background so server startup and
+  // route mounting are not blocked on CLI health checks.
+  yield* refreshSnapshot().pipe(Effect.ignoreCause({ log: true }), Effect.forkScoped);
+
   return {
-    getSnapshot: input.getSettings.pipe(
-      Effect.flatMap(applySnapshot),
-      Effect.tapError(Effect.logError),
-      Effect.orDie,
-    ),
+    getSnapshot: Ref.get(snapshotRef),
     refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
     get streamChanges() {
       return Stream.fromPubSub(changesPubSub);

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -211,7 +211,9 @@ export function buildPendingServerProvider(input: {
     ...(input.runtimeSupport !== undefined ? { runtimeSupport: input.runtimeSupport } : {}),
     probe: input.enabled
       ? {
-          installed: true,
+          // Pending snapshots intentionally keep install state "unknown" until
+          // the first real CLI probe completes.
+          installed: false,
           version: null,
           status: "warning",
           auth: { status: "unknown" },

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -192,6 +192,41 @@ export function buildServerProvider(input: {
   };
 }
 
+export function buildPendingServerProvider(input: {
+  provider: ServerProvider["provider"];
+  enabled: boolean;
+  checkedAt: string;
+  models: ReadonlyArray<ServerProviderModel>;
+  disabledMessage?: string;
+  checkingMessage?: string;
+  experimental?: boolean;
+  runtimeSupport?: ServerProviderRuntimeSupport;
+}): ServerProvider {
+  return buildServerProvider({
+    provider: input.provider,
+    enabled: input.enabled,
+    checkedAt: input.checkedAt,
+    models: input.models,
+    ...(input.experimental !== undefined ? { experimental: input.experimental } : {}),
+    ...(input.runtimeSupport !== undefined ? { runtimeSupport: input.runtimeSupport } : {}),
+    probe: input.enabled
+      ? {
+          installed: true,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: input.checkingMessage ?? "Checking provider status…",
+        }
+      : {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: input.disabledMessage ?? "This provider is disabled in Beppo settings.",
+        },
+  });
+}
+
 export function buildExperimentalAcpServerProvider(input: {
   provider: Extract<ServerProvider["provider"], "githubCopilot" | "cursor">;
   enabled: boolean;

--- a/apps/web/src/components/SidebarProviderStatusList.tsx
+++ b/apps/web/src/components/SidebarProviderStatusList.tsx
@@ -50,12 +50,21 @@ function getProviderStatusDotClass(provider: ServerProvider): string {
   return PROVIDER_STATUS_DOT_CLASS[provider.status];
 }
 
+function isPendingProviderCheck(provider: ServerProvider): boolean {
+  const message = provider.message?.toLowerCase() ?? "";
+  return provider.enabled && provider.status === "warning" && message.startsWith("checking ");
+}
+
 function getProviderHeadline(provider: ServerProvider): {
   icon: typeof ShieldCheckIcon;
   label: string;
 } {
   if (!provider.enabled) {
     return { icon: ShieldOffIcon, label: "Disabled" };
+  }
+
+  if (isPendingProviderCheck(provider)) {
+    return { icon: ShieldAlertIcon, label: "Checking…" };
   }
 
   if (!provider.installed) {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -164,11 +164,20 @@ function getProviderSummary(provider: ServerProvider | undefined) {
       detail: "Waiting for the server to report installation and authentication details.",
     };
   }
+  const normalizedMessage = provider.message?.toLowerCase() ?? "";
+  const isPendingCheck =
+    provider.enabled && provider.status === "warning" && normalizedMessage.startsWith("checking ");
   if (!provider.enabled) {
     return {
       headline: "Disabled",
       detail:
         provider.message ?? "This provider is installed but disabled for new sessions in Beppo.",
+    };
+  }
+  if (isPendingCheck) {
+    return {
+      headline: "Checking provider status",
+      detail: provider.message ?? "Waiting for the server to finish the first provider probe.",
     };
   }
   if (!provider.installed) {


### PR DESCRIPTION
## Summary
- stop provider health checks from blocking desktop/server startup
- return lightweight placeholder provider snapshots immediately and refresh them in the background
- keep Codex and Claude provider cards updating once the real probe completes

## Validation
- bun fmt
- bun lint
- bun typecheck
- bun run build:desktop
- verified desktop-mode server now returns 200 for `/`, `/index.html`, and `/api/project-favicon`
- installed the freshly built arm64 DMG into `/Applications/Beppo.app` and verified the app window launches successfully with Computer Use

## Root cause
Desktop startup waits for the embedded server to serve `/`. Provider status probing was happening during server construction, so the Bun HTTP server bound its port before the real route layer attached. That left the default Bun `404 not found` handler in place long enough for desktop bootstrap to time out and abort.
